### PR TITLE
Add configurable default server to allow omitting server name

### DIFF
--- a/Examples/config.json.default
+++ b/Examples/config.json.default
@@ -1,1 +1,1 @@
-{"prefix": ";", "token": "replacemewithdiscordtoken"}
+{"prefix": ";", "token": "replacemewithdiscordtoken", "default_server": "default"}

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ In addition to the implemented RCON commands, the bot has a few advanced functio
 * ``;matchsetup <CT Team> <T Team> <server>`` using the team aliases setup in aliases.json will push players to the correct teams in game, pause 10 seconds then issue ResetSND
  * ``;anyoneplaying`` will give a summary report of all servers controlled by the bot
  * ``;custom "<command string>" <server>`` will pass the command string along to RCON and presents back whatever data is returned (if any). This is useful for maps with rcon interfaces
+* If you have a server called "default", you can omit the server name from commands. To set a different default server name, set `server_name` key in config.json
 
 
 # Known issues with Rcon that bot can't fix

--- a/bot/cogs/pavlov.py
+++ b/bot/cogs/pavlov.py
@@ -9,7 +9,7 @@ import aiohttp
 import discord
 from discord.ext import commands
 
-from bot.utils import Paginator, aliases, servers
+from bot.utils import Paginator, aliases, servers, config
 from bot.utils.pavlov import exec_server_command
 from bot.utils.steamplayer import SteamPlayer
 from bot.utils.text_to_image import text_to_image
@@ -116,7 +116,7 @@ class Pavlov(commands.Cog):
         await teams_cog.teams(ctx)
 
     @commands.command()
-    async def serverinfo(self, ctx, server_name: str):
+    async def serverinfo(self, ctx, server_name: str=config.default_server):
         """`{prefix}serverinfo <server_name>`
 
         **Example**: `{prefix}serverinfo rush`
@@ -155,7 +155,7 @@ class Pavlov(commands.Cog):
         await ctx.send(embed=embed)
 
     @commands.command()
-    async def blacklist(self, ctx, server_name: str):
+    async def blacklist(self, ctx, server_name: str=config.default_server):
         """`{prefix}blacklist <server_name>` 
 
         **Example**: `{prefix}blacklist rush`
@@ -172,7 +172,7 @@ class Pavlov(commands.Cog):
         await ctx.send(embed=embed)
 
     @commands.command()
-    async def itemlist(self, ctx, server_name: str):
+    async def itemlist(self, ctx, server_name: str=config.default_server):
         """`{prefix}itemlist <servername>` 
 
         **Example**: `{prefix}itemlist snd1`
@@ -189,7 +189,7 @@ class Pavlov(commands.Cog):
         await ctx.send(embed=embed)
 
     @commands.command()  # Exceeds Helptext embed, maplist hidden for now
-    async def maplist(self, ctx, server_name: str):
+    async def maplist(self, ctx, server_name: str=config.default_server):
         """`{prefix}maplist <server_name>`
 
         **Example**: `{prefix}maplist rush`
@@ -206,7 +206,7 @@ class Pavlov(commands.Cog):
         await ctx.send(embed=embed)
 
     @commands.command()
-    async def players(self, ctx, server_name: str):
+    async def players(self, ctx, server_name: str=config.default_server):
         """`{prefix}players <server_name>`
 
         **Example**: `{prefix}players rush`
@@ -223,7 +223,7 @@ class Pavlov(commands.Cog):
         await ctx.send(embed=embed)
 
     @commands.command()
-    async def playerinfo(self, ctx, player_arg: str, server_name: str):
+    async def playerinfo(self, ctx, player_arg: str, server_name: str=config.default_server):
         """`{prefix}playerinfo <player_id> <server_name>`
 
         **Example**: `{prefix}playerinfo 89374583439127 rush`

--- a/bot/cogs/pavlov_admin.py
+++ b/bot/cogs/pavlov_admin.py
@@ -3,7 +3,7 @@ import logging
 import discord
 from discord.ext import commands
 
-from bot.utils import SteamPlayer
+from bot.utils import SteamPlayer, config
 from bot.utils.pavlov import check_perm_admin, exec_server_command
 
 
@@ -16,7 +16,7 @@ class PavlovAdmin(commands.Cog):
         logging.info(f"{type(self).__name__} Cog ready.")
 
     @commands.command()
-    async def giveitem(self, ctx, player_arg: str, item_id: str, server_name: str):
+    async def giveitem(self, ctx, player_arg: str, item_id: str, server_name: str=config.default_server):
         """`{prefix}giveitem <player_id> <item_id> <server_name>`
 
         **Requires**: Admin permissions for the server
@@ -38,7 +38,7 @@ class PavlovAdmin(commands.Cog):
         await ctx.send(embed=embed)
 
     @commands.command()
-    async def givecash(self, ctx, player_arg: str, cash_amount: str, server_name: str):
+    async def givecash(self, ctx, player_arg: str, cash_amount: str, server_name: str=config.default_server):
         """`{prefix}givecash <player_id> <cash_amount> <server_name>`
 
         **Requires**: Admin permissions for the server
@@ -62,7 +62,7 @@ class PavlovAdmin(commands.Cog):
         await ctx.send(embed=embed)
 
     @commands.command()
-    async def giveteamcash(self, ctx, team_id: str, cash_amount: str, server_name: str):
+    async def giveteamcash(self, ctx, team_id: str, cash_amount: str, server_name: str=config.default_server):
         """`{prefix}giveteamcash <team_id> <cash_amount> <server_name>`
 
         **Requires**: Admin permissions for the server
@@ -81,7 +81,7 @@ class PavlovAdmin(commands.Cog):
         await ctx.send(embed=embed)
 
     @commands.command()
-    async def setplayerskin(self, ctx, player_arg: str, skin_id: str, server_name: str):
+    async def setplayerskin(self, ctx, player_arg: str, skin_id: str, server_name: str=config.default_server):
         """`{prefix}setplayerskin <player_id> <skin_id> <server_name>`
 
         **Requires**: Admin permissions for the server
@@ -105,7 +105,7 @@ class PavlovAdmin(commands.Cog):
         await ctx.send(embed=embed)
 
     @commands.command()
-    async def custom(self, ctx, rcon_command: str, server_name: str):
+    async def custom(self, ctx, rcon_command: str, server_name: str=config.default_server):
         """`{prefix}custom "<rcon_command with args>" server_name`
 
         **Example**: `{prefix}custom ServerInfo rush`

--- a/bot/cogs/pavlov_captain.py
+++ b/bot/cogs/pavlov_captain.py
@@ -113,7 +113,7 @@ class PavlovCaptain(commands.Cog):
 
     @commands.command()
     async def matchsetup(
-        self, ctx, team_a_name: str, team_b_name: str, server_name: str
+        self, ctx, team_a_name: str, team_b_name: str, server_name: str=config.default_server
     ):
         """`{prefix}matchsetup <CT team name> <T team name> <server name>`
 

--- a/bot/cogs/pavlov_captain.py
+++ b/bot/cogs/pavlov_captain.py
@@ -5,7 +5,7 @@ from datetime import datetime
 import discord
 from discord.ext import commands
 
-from bot.utils import SteamPlayer, aliases
+from bot.utils import SteamPlayer, aliases, config
 from bot.utils.pavlov import check_perm_captain, exec_server_command
 
 
@@ -22,7 +22,7 @@ class PavlovCaptain(commands.Cog):
         logging.info(f"{type(self).__name__} Cog ready.")
 
     @commands.command()
-    async def switchmap(self, ctx, map_name: str, game_mode: str, server_name: str):
+    async def switchmap(self, ctx, map_name: str, game_mode: str, server_name: str=config.default_server):
         """`{prefix}switchmap <map_name> <game_mode> <server_name>`
 
         **Requires**: Captain permissions or higher for the server
@@ -48,7 +48,7 @@ class PavlovCaptain(commands.Cog):
         await ctx.send(embed=embed)
 
     @commands.command()
-    async def resetsnd(self, ctx, server_name: str):
+    async def resetsnd(self, ctx, server_name: str=config.default_server):
         """`{prefix}resetsnd <server_name>`
 
         **Requires**: Captain permissions or higher for the server
@@ -67,7 +67,7 @@ class PavlovCaptain(commands.Cog):
         await ctx.send(embed=embed)
 
     @commands.command()
-    async def switchteam(self, ctx, player_arg: str, team_id: str, server_name: str):
+    async def switchteam(self, ctx, player_arg: str, team_id: str, server_name: str=config.default_server):
         """`{prefix}switchteam <player_id> <team_id> <server_name>`
 
         **Requires**: Captain permissions or higher for the server
@@ -93,7 +93,7 @@ class PavlovCaptain(commands.Cog):
         await ctx.send(embed=embed)
 
     @commands.command()
-    async def rotatemap(self, ctx, server_name: str):
+    async def rotatemap(self, ctx, server_name: str=config.default_server):
         """`{prefix}rotatemap <server_name>`
 
         **Requires**: Captain permissions or higher for the server

--- a/bot/cogs/pavlov_mod.py
+++ b/bot/cogs/pavlov_mod.py
@@ -5,7 +5,7 @@ from datetime import datetime
 import discord
 from discord.ext import commands
 
-from bot.utils import SteamPlayer
+from bot.utils import SteamPlayer, config
 from bot.utils.pavlov import check_perm_moderator, exec_server_command
 
 
@@ -18,7 +18,7 @@ class PavlovMod(commands.Cog):
         logging.info(f"{type(self).__name__} Cog ready.")
 
     @commands.command()
-    async def ban(self, ctx, player_arg: str, server_name: str):
+    async def ban(self, ctx, player_arg: str, server_name: str=config.default_server):
         """`{prefix}ban <player_id> <server_name>`
 
         **Requires**: Moderator permissions or higher for the server
@@ -40,7 +40,7 @@ class PavlovMod(commands.Cog):
         await ctx.send(embed=embed)
 
     @commands.command()
-    async def kill(self, ctx, player_arg: str, server_name: str):
+    async def kill(self, ctx, player_arg: str, server_name: str=config.default_server):
         """`{prefix}kill <player_id> <server_name>`
 
         **Requires**: Moderator permissions or higher for the server
@@ -64,7 +64,7 @@ class PavlovMod(commands.Cog):
         await ctx.send(embed=embed)
 
     @commands.command()
-    async def kick(self, ctx, player_arg: str, server_name: str):
+    async def kick(self, ctx, player_arg: str, server_name: str=config.default_server):
         """`{prefix}kick <player_id> <server_name>`
 
         **Requires**: Moderator permissions or higher for the server
@@ -88,7 +88,7 @@ class PavlovMod(commands.Cog):
         await ctx.send(embed=embed)
 
     @commands.command()
-    async def unban(self, ctx, player_arg: str, server_name: str):
+    async def unban(self, ctx, player_arg: str, server_name: str=config.default_server):
         """`{prefix}unban <player_id> <server_name>`
 
         **Requires**: Moderator permissions or higher for the server

--- a/bot/utils/config.py
+++ b/bot/utils/config.py
@@ -1,7 +1,7 @@
 import json
 import os
 
-default_config = {"prefix": ";", "token": ""}
+default_config = {"prefix": ";", "token": "", "default_server": "default"}
 
 
 class Config:
@@ -15,6 +15,7 @@ class Config:
             self.config = json.load(file)
         self.prefix = self.config.get("prefix", default_config.get("prefix"))
         self.token = self.config.get("token", default_config.get("token"))
+        self.default_server = self.config.get("default_server", default_config.get("default_server"))
 
     def store(self):
         c = {"prefix": self.prefix, "token": self.token}


### PR DESCRIPTION
Disclaimer: I have no idea what I'm doing

Add config option for `server_name` then pass as default value for server param to all commands.

Should this actually affect all commands? Maybe for some things (like admin commands, at least for `blacklist`) it's better to require specifying a server. I wasn't sure how to update the docs for each separately so consistency was easier.

Also not sure if using `None` then assignment is preferable to using config directly. Since we could potentially then mutate the config option

Fixes https://github.com/makupi/pavlov-bot/issues/56