### PR TITLE
Add Quest String based ID support

### DIFF
--- a/bot/cogs/pavlov.py
+++ b/bot/cogs/pavlov.py
@@ -71,7 +71,9 @@ class Pavlov(commands.Cog):
     async def servers(self, ctx):
         """`{prefix}servers` - *Lists available servers*"""
         server_names = servers.get_names()
-        embed = discord.Embed(title="Servers", description="\n- ".join([""] + server_names))
+        embed = discord.Embed(
+            title="Servers", description="\n- ".join([""] + server_names)
+        )
         await ctx.send(embed=embed)
 
     @commands.group(invoke_without_command=True, pass_context=True, aliases=["alias"])
@@ -116,7 +118,7 @@ class Pavlov(commands.Cog):
         await teams_cog.teams(ctx)
 
     @commands.command()
-    async def serverinfo(self, ctx, server_name: str=config.default_server):
+    async def serverinfo(self, ctx, server_name: str = config.default_server):
         """`{prefix}serverinfo <server_name>`
 
         **Example**: `{prefix}serverinfo rush`
@@ -143,7 +145,9 @@ class Pavlov(commands.Cog):
         embed = discord.Embed(description=f"**ServerInfo** for `{server_name}`")
         if map_image:
             embed.set_thumbnail(url=map_image)
-        embed.add_field(name="Server Name", value=server_info.get("ServerName"), inline=False)
+        embed.add_field(
+            name="Server Name", value=server_info.get("ServerName"), inline=False
+        )
         embed.add_field(name="Round State", value=server_info.get("RoundState"))
         embed.add_field(name="Players", value=server_info.get("PlayerCount"))
         embed.add_field(name="Game Mode", value=server_info.get("GameMode"))
@@ -155,14 +159,16 @@ class Pavlov(commands.Cog):
         await ctx.send(embed=embed)
 
     @commands.command()
-    async def blacklist(self, ctx, server_name: str=config.default_server):
-        """`{prefix}blacklist <server_name>` 
+    async def blacklist(self, ctx, server_name: str = config.default_server):
+        """`{prefix}blacklist <server_name>`
 
         **Example**: `{prefix}blacklist rush`
         """
         data = await exec_server_command(ctx, server_name, "Blacklist")
         black_list = data.get("BlackList")
-        embed = discord.Embed(description=f"**Blacklisted players** on `{server_name}`:\n")
+        embed = discord.Embed(
+            description=f"**Blacklisted players** on `{server_name}`:\n"
+        )
         if len(black_list) == 0:
             embed.description = f"Currently no Blacklisted players on `{server_name}`"
         for player in black_list:
@@ -172,8 +178,8 @@ class Pavlov(commands.Cog):
         await ctx.send(embed=embed)
 
     @commands.command()
-    async def itemlist(self, ctx, server_name: str=config.default_server):
-        """`{prefix}itemlist <servername>` 
+    async def itemlist(self, ctx, server_name: str = config.default_server):
+        """`{prefix}itemlist <servername>`
 
         **Example**: `{prefix}itemlist snd1`
         """
@@ -189,7 +195,7 @@ class Pavlov(commands.Cog):
         await ctx.send(embed=embed)
 
     @commands.command()  # Exceeds Helptext embed, maplist hidden for now
-    async def maplist(self, ctx, server_name: str=config.default_server):
+    async def maplist(self, ctx, server_name: str = config.default_server):
         """`{prefix}maplist <server_name>`
 
         **Example**: `{prefix}maplist rush`
@@ -200,13 +206,15 @@ class Pavlov(commands.Cog):
         if len(map_list) == 0:
             embed.description = f"Currently no active maps on `{server_name}`"
         for _map in map_list:
-            embed.description += f"\n - {_map.get('MapId', '')} <{_map.get('GameMode')}>"
+            embed.description += (
+                f"\n - {_map.get('MapId', '')} <{_map.get('GameMode')}>"
+            )
         if ctx.batch_exec:
             return embed.description
         await ctx.send(embed=embed)
 
     @commands.command()
-    async def players(self, ctx, server_name: str=config.default_server):
+    async def players(self, ctx, server_name: str = config.default_server):
         """`{prefix}players <server_name>`
 
         **Example**: `{prefix}players rush`
@@ -217,19 +225,25 @@ class Pavlov(commands.Cog):
         if len(player_list) == 0:
             embed.description = f"Currently no active players on `{server_name}`"
         for player in player_list:
-            embed.description += f"\n - {player.get('Username', '')} <{player.get('UniqueId')}>"
+            embed.description += (
+                f"\n - {player.get('Username', '')} <{player.get('UniqueId')}>"
+            )
         if ctx.batch_exec:
             return embed.description
         await ctx.send(embed=embed)
 
     @commands.command()
-    async def playerinfo(self, ctx, player_arg: str, server_name: str=config.default_server):
+    async def playerinfo(
+        self, ctx, player_arg: str, server_name: str = config.default_server
+    ):
         """`{prefix}playerinfo <player_id> <server_name>`
 
         **Example**: `{prefix}playerinfo 89374583439127 rush`
         """
         player = SteamPlayer.convert(player_arg)
-        data = await exec_server_command(ctx, server_name, f"InspectPlayer {player.unique_id}")
+        data = await exec_server_command(
+            ctx, server_name, f"InspectPlayer {player.unique_id}"
+        )
         player_info = data.get("PlayerInfo")
         if ctx.batch_exec:
             return player_info
@@ -280,7 +294,9 @@ class Pavlov(commands.Cog):
                     embed.add_field(name=args, value="execution failed", inline=False)
             else:
                 embed.add_field(
-                    name=args, value="execution failed - command not found", inline=False,
+                    name=args,
+                    value="execution failed - command not found",
+                    inline=False,
                 )
         embed.set_footer(text=f"Execution time: {datetime.now() - before}")
         await ctx.send(embed=embed)

--- a/bot/cogs/pavlov_admin.py
+++ b/bot/cogs/pavlov_admin.py
@@ -16,7 +16,13 @@ class PavlovAdmin(commands.Cog):
         logging.info(f"{type(self).__name__} Cog ready.")
 
     @commands.command()
-    async def giveitem(self, ctx, player_arg: str, item_id: str, server_name: str=config.default_server):
+    async def giveitem(
+        self,
+        ctx,
+        player_arg: str,
+        item_id: str,
+        server_name: str = config.default_server,
+    ):
         """`{prefix}giveitem <player_id> <item_id> <server_name>`
 
         **Requires**: Admin permissions for the server
@@ -25,7 +31,9 @@ class PavlovAdmin(commands.Cog):
         if not await check_perm_admin(ctx, server_name):
             return
         player = SteamPlayer.convert(player_arg)
-        data = await exec_server_command(ctx, server_name, f"GiveItem {player.unique_id} {item_id}")
+        data = await exec_server_command(
+            ctx, server_name, f"GiveItem {player.unique_id} {item_id}"
+        )
         give_team = data.get("GiveItem")
         if ctx.batch_exec:
             return give_team
@@ -34,11 +42,19 @@ class PavlovAdmin(commands.Cog):
                 description=f"**Failed** to give {item_id} to <{player.unique_id}>"
             )
         else:
-            embed = discord.Embed(description=f"{item_id} given to <{player.unique_id}>")
+            embed = discord.Embed(
+                description=f"{item_id} given to <{player.unique_id}>"
+            )
         await ctx.send(embed=embed)
 
     @commands.command()
-    async def givecash(self, ctx, player_arg: str, cash_amount: str, server_name: str=config.default_server):
+    async def givecash(
+        self,
+        ctx,
+        player_arg: str,
+        cash_amount: str,
+        server_name: str = config.default_server,
+    ):
         """`{prefix}givecash <player_id> <cash_amount> <server_name>`
 
         **Requires**: Admin permissions for the server
@@ -58,11 +74,19 @@ class PavlovAdmin(commands.Cog):
                 description=f"**Failed** to give {cash_amount} to <{player.unique_id}>"
             )
         else:
-            embed = discord.Embed(description=f"{cash_amount} given to <{player.unique_id}>")
+            embed = discord.Embed(
+                description=f"{cash_amount} given to <{player.unique_id}>"
+            )
         await ctx.send(embed=embed)
 
     @commands.command()
-    async def giveteamcash(self, ctx, team_id: str, cash_amount: str, server_name: str=config.default_server):
+    async def giveteamcash(
+        self,
+        ctx,
+        team_id: str,
+        cash_amount: str,
+        server_name: str = config.default_server,
+    ):
         """`{prefix}giveteamcash <team_id> <cash_amount> <server_name>`
 
         **Requires**: Admin permissions for the server
@@ -70,18 +94,28 @@ class PavlovAdmin(commands.Cog):
         """
         if not await check_perm_admin(ctx, server_name):
             return
-        data = await exec_server_command(ctx, server_name, f"GiveTeamCash {team_id} {cash_amount}")
+        data = await exec_server_command(
+            ctx, server_name, f"GiveTeamCash {team_id} {cash_amount}"
+        )
         give_team_cash = data.get("GiveTeamCash")
         if ctx.batch_exec:
             return give_team_cash
         if not give_team_cash:
-            embed = discord.Embed(description=f"**Failed** to give {cash_amount} to <{team_id}>")
+            embed = discord.Embed(
+                description=f"**Failed** to give {cash_amount} to <{team_id}>"
+            )
         else:
             embed = discord.Embed(description=f"{cash_amount} given to <{team_id}>")
         await ctx.send(embed=embed)
 
     @commands.command()
-    async def setplayerskin(self, ctx, player_arg: str, skin_id: str, server_name: str=config.default_server):
+    async def setplayerskin(
+        self,
+        ctx,
+        player_arg: str,
+        skin_id: str,
+        server_name: str = config.default_server,
+    ):
         """`{prefix}setplayerskin <player_id> <skin_id> <server_name>`
 
         **Requires**: Admin permissions for the server
@@ -101,11 +135,15 @@ class PavlovAdmin(commands.Cog):
                 description=f"**Failed** to set <{player.unique_id}>'s skin to {skin_id}"
             )
         else:
-            embed = discord.Embed(description=f"<{player.unique_id}>'s skin set to {skin_id}")
+            embed = discord.Embed(
+                description=f"<{player.unique_id}>'s skin set to {skin_id}"
+            )
         await ctx.send(embed=embed)
 
     @commands.command()
-    async def custom(self, ctx, rcon_command: str, server_name: str=config.default_server):
+    async def custom(
+        self, ctx, rcon_command: str, server_name: str = config.default_server
+    ):
         """`{prefix}custom "<rcon_command with args>" server_name`
 
         **Example**: `{prefix}custom ServerInfo rush`

--- a/bot/cogs/pavlov_captain.py
+++ b/bot/cogs/pavlov_captain.py
@@ -22,7 +22,13 @@ class PavlovCaptain(commands.Cog):
         logging.info(f"{type(self).__name__} Cog ready.")
 
     @commands.command()
-    async def switchmap(self, ctx, map_name: str, game_mode: str, server_name: str=config.default_server):
+    async def switchmap(
+        self,
+        ctx,
+        map_name: str,
+        game_mode: str,
+        server_name: str = config.default_server,
+    ):
         """`{prefix}switchmap <map_name> <game_mode> <server_name>`
 
         **Requires**: Captain permissions or higher for the server
@@ -48,7 +54,7 @@ class PavlovCaptain(commands.Cog):
         await ctx.send(embed=embed)
 
     @commands.command()
-    async def resetsnd(self, ctx, server_name: str=config.default_server):
+    async def resetsnd(self, ctx, server_name: str = config.default_server):
         """`{prefix}resetsnd <server_name>`
 
         **Requires**: Captain permissions or higher for the server
@@ -67,7 +73,13 @@ class PavlovCaptain(commands.Cog):
         await ctx.send(embed=embed)
 
     @commands.command()
-    async def switchteam(self, ctx, player_arg: str, team_id: str, server_name: str=config.default_server):
+    async def switchteam(
+        self,
+        ctx,
+        player_arg: str,
+        team_id: str,
+        server_name: str = config.default_server,
+    ):
         """`{prefix}switchteam <player_id> <team_id> <server_name>`
 
         **Requires**: Captain permissions or higher for the server
@@ -93,7 +105,7 @@ class PavlovCaptain(commands.Cog):
         await ctx.send(embed=embed)
 
     @commands.command()
-    async def rotatemap(self, ctx, server_name: str=config.default_server):
+    async def rotatemap(self, ctx, server_name: str = config.default_server):
         """`{prefix}rotatemap <server_name>`
 
         **Requires**: Captain permissions or higher for the server
@@ -113,7 +125,11 @@ class PavlovCaptain(commands.Cog):
 
     @commands.command()
     async def matchsetup(
-        self, ctx, team_a_name: str, team_b_name: str, server_name: str=config.default_server
+        self,
+        ctx,
+        team_a_name: str,
+        team_b_name: str,
+        server_name: str = config.default_server,
     ):
         """`{prefix}matchsetup <CT team name> <T team name> <server name>`
 

--- a/bot/cogs/pavlov_mod.py
+++ b/bot/cogs/pavlov_mod.py
@@ -18,7 +18,7 @@ class PavlovMod(commands.Cog):
         logging.info(f"{type(self).__name__} Cog ready.")
 
     @commands.command()
-    async def ban(self, ctx, player_arg: str, server_name: str=config.default_server):
+    async def ban(self, ctx, player_arg: str, server_name: str = config.default_server):
         """`{prefix}ban <player_id> <server_name>`
 
         **Requires**: Moderator permissions or higher for the server
@@ -40,7 +40,9 @@ class PavlovMod(commands.Cog):
         await ctx.send(embed=embed)
 
     @commands.command()
-    async def kill(self, ctx, player_arg: str, server_name: str=config.default_server):
+    async def kill(
+        self, ctx, player_arg: str, server_name: str = config.default_server
+    ):
         """`{prefix}kill <player_id> <server_name>`
 
         **Requires**: Moderator permissions or higher for the server
@@ -64,7 +66,9 @@ class PavlovMod(commands.Cog):
         await ctx.send(embed=embed)
 
     @commands.command()
-    async def kick(self, ctx, player_arg: str, server_name: str=config.default_server):
+    async def kick(
+        self, ctx, player_arg: str, server_name: str = config.default_server
+    ):
         """`{prefix}kick <player_id> <server_name>`
 
         **Requires**: Moderator permissions or higher for the server
@@ -88,7 +92,9 @@ class PavlovMod(commands.Cog):
         await ctx.send(embed=embed)
 
     @commands.command()
-    async def unban(self, ctx, player_arg: str, server_name: str=config.default_server):
+    async def unban(
+        self, ctx, player_arg: str, server_name: str = config.default_server
+    ):
         """`{prefix}unban <player_id> <server_name>`
 
         **Requires**: Moderator permissions or higher for the server

--- a/bot/utils/aliases.py
+++ b/bot/utils/aliases.py
@@ -7,6 +7,7 @@ from bot.utils.steamplayer import SteamPlayer
 
 DEFAULT_FORMAT = {"maps": {}, "players": {}, "teams": {}}
 MAP_NAME_REGEX = r"UGC[0-9]*"
+STRING_ID_CHARACTER_LENGTH = 24
 
 
 def check_map_already_label(name):
@@ -15,11 +16,14 @@ def check_map_already_label(name):
     return False
 
 
-def check_player_already_int(name):
+def check_player_already_id(name):
     try:
         int(name)
         return True
     except ValueError:
+        if len(name) >= STRING_ID_CHARACTER_LENGTH:
+            if int(name, 16):  # check if hexadecimal
+                return True
         return False
 
 
@@ -102,7 +106,7 @@ class Aliases:
         return self.get("maps", name)
 
     def get_player(self, name: str):
-        if check_player_already_int(name):
+        if check_player_already_id(name):
             return name
         return self.get("players", name)
 

--- a/bot/utils/aliases.py
+++ b/bot/utils/aliases.py
@@ -7,7 +7,7 @@ from bot.utils.steamplayer import SteamPlayer
 
 DEFAULT_FORMAT = {"maps": {}, "players": {}, "teams": {}}
 MAP_NAME_REGEX = r"UGC[0-9]*"
-STRING_ID_CHARACTER_LENGTH = 24
+STRING_ID_CHARACTER_LENGTH = 16
 
 
 def check_map_already_label(name):

--- a/bot/utils/config.py
+++ b/bot/utils/config.py
@@ -15,7 +15,9 @@ class Config:
             self.config = json.load(file)
         self.prefix = self.config.get("prefix", default_config.get("prefix"))
         self.token = self.config.get("token", default_config.get("token"))
-        self.default_server = self.config.get("default_server", default_config.get("default_server"))
+        self.default_server = self.config.get(
+            "default_server", default_config.get("default_server")
+        )
 
     def store(self):
         c = {"prefix": self.prefix, "token": self.token}


### PR DESCRIPTION
- If "player" argument passed is an `integer` it is used directly as an argument
- `NEW`: If argument is a `string` with a length >= **16** and hexadecimal (e.g. `0022a0356594df59ebaf8ce9c10f145`) it is used directly as an argument.
- For all other cases, it is checked whether the `string` argument passed is defined as an alias.

This should work for both Quest IDs mentioned in #52 

Closes #52 