### PR TITLE
Updated teamssetup command to reset team before adding

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ In addition to the implemented RCON commands, the bot has a few advanced functio
  * ``;custom "<command string>" <server>`` will pass the command string along to RCON and presents back whatever data is returned (if any). This is useful for maps with rcon interfaces
 * If you have a server called "default", you can omit the server name from commands. To set a different default server name, set `server_name` key in config.json
 * ``;flush <server>`` will randomly pick a player who isn't in aliases.json and kick them from the server to make room for a registered player. 
-* ``;command <command_name> will allow you to execute pre-defined commandline commands in commands.json on the local server running the bot. Useful for automation of things like starting and stopping pavlovserver instances or clearing disk space on server full of maps. 
+* ``;command <command_name>`` will allow you to execute pre-defined commandline commands in commands.json on the local server running the bot. Useful for automation of things like starting and stopping pavlovserver instances or clearing disk space on server full of maps. 
 
 ## Quest IDs 
 

--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -15,7 +15,7 @@ handler.setFormatter(formatter)
 logger.addHandler(handler)
 logger.setLevel(logging.INFO)
 
-__version__ = "0.4.0"
+__version__ = "0.4.2"
 
 invite_link = "https://discordapp.com/api/oauth2/authorize?client_id={}&scope=bot&permissions=8192"
 

--- a/bot/cogs/teams.py
+++ b/bot/cogs/teams.py
@@ -27,6 +27,7 @@ class Teams(commands.Cog):
         if not await check_perm_captain(ctx, global_check=True):
             return
         team = aliases.get_team(team_name)
+        team.ringers_reset()
         players = players_arg.split(',')
         for player in players:
             player = SteamPlayer.convert(player)


### PR DESCRIPTION
Tested and working. Gets rid of extra steps of clearing ringers first before setting up new one. 