### PR TITLE
Small improvements for map command

### DIFF
--- a/bot/cogs/pavlov.py
+++ b/bot/cogs/pavlov.py
@@ -65,7 +65,7 @@ class Pavlov(commands.Cog):
             self._map_aliases[map_label] = {"name": map_name, "image": map_image}
             return map_name, map_image
         except Exception as ex:
-            logging.error(f"Getting map label failed with {ex}")
+            logging.error(f"Getting map label {map_label} failed with {ex}")
         return None, None
 
     @commands.command()

--- a/bot/cogs/pavlov_captain.py
+++ b/bot/cogs/pavlov_captain.py
@@ -21,8 +21,8 @@ class PavlovCaptain(commands.Cog):
     async def on_ready(self):
         logging.info(f"{type(self).__name__} Cog ready.")
 
-    @commands.command()
-    async def switchmap(
+    @commands.command(aliases=["switchmap"])
+    async def map(
         self,
         ctx,
         map_name: str,
@@ -104,7 +104,7 @@ class PavlovCaptain(commands.Cog):
             )
         await ctx.send(embed=embed)
 
-    @commands.command()
+    @commands.command(aliases=["next"])
     async def rotatemap(self, ctx, server_name: str = config.default_server):
         """`{prefix}rotatemap <server_name>`
 

--- a/bot/utils/aliases.py
+++ b/bot/utils/aliases.py
@@ -2,11 +2,14 @@ import json
 import os
 import re
 from typing import List, Tuple
+import urllib.parse as urlparse
+from urllib.parse import parse_qs
 
 from bot.utils.steamplayer import SteamPlayer
 
 DEFAULT_FORMAT = {"maps": {}, "players": {}, "teams": {}}
 MAP_NAME_REGEX = r"UGC[0-9]*"
+WORKSHOP_URL = "https://steamcommunity.com/sharedfiles/filedetails/"
 STRING_ID_CHARACTER_LENGTH = 16
 
 
@@ -109,6 +112,11 @@ class Aliases:
         self.teams = teams
 
     def get_map(self, name: str):
+        if name.startswith(WORKSHOP_URL):
+            parsed_url = urlparse.urlparse(name)
+            # try / except for KeyError if URL doesn't have QS / ID
+            id = parse_qs(parsed_url.query)['id'][0]
+            return f"UGC{id}"
         if check_map_already_label(name):
             return name
         return self.get("maps", name)


### PR DESCRIPTION
Couple of small quality-of-life improvements for when typing in discord from VR.

1. Rename `switchmap` to `map` (keep switchmap as an alias so it still works)
2. Add `next` alias to `rotatemap`
3. Allow pasting steam workshop URLs when pasting maps (slightly easier than copying ID + adding UGC)

`;map https://steamcommunity.com/sharedfiles/filedetails/?id=2378760954 dm`
