### PR TITLE
Appended the aliases.json.default with the gamemodes, added "get_gamemodes" and "aliases gamemodes"

### DIFF
--- a/Examples/aliases.json.default
+++ b/Examples/aliases.json.default
@@ -11,5 +11,22 @@
   "teams": {
     "PCteam1": [76568423451070460, 76568768421070460],
     "Questteam2": ["Questplayer1", "Questplayer2"]
+  },
+  "gamemodes":{
+    "DM": 	        "Death match",
+    "KOTH": 	      "King of the hill",
+    "GUN": 	        "Gun game",
+    "OITC": 	      "One in the chamber",
+    "SND": 	        "Search and destroy",
+    "TANKTDM": 	    "WW2 Team Death Match",
+    "TDM": 	        "Team Death Match",
+    "TTT": 	        "Trouble in Terrorist Town",
+    "TTTclassic": 	"TTT with only innocent/traitor/detective",
+    "WW2GUN": 	    "WW2 gun game",
+    "ZWV": 	        "Zombie wave survival",
+    "HIDE": 	      "The Hidden",
+    "INFECTION": 	  "Hidden infection",
+    "PUSH": 	      "Push",
+    "PH": 	        "Prop hunt"
   }
 }

--- a/bot/cogs/pavlov.py
+++ b/bot/cogs/pavlov.py
@@ -87,6 +87,7 @@ class Pavlov(commands.Cog):
         await self.maps_aliases(ctx)
         await self.players_aliases(ctx)
         await self.teams_aliases(ctx)
+        await self.gamemodes_aliases(ctx)
 
     @aliases.command(name="maps")
     async def maps_aliases(self, ctx):
@@ -100,6 +101,20 @@ class Pavlov(commands.Cog):
             await paginator.create(ctx, embed=embed)
         else:
             embed.description = "No aliases exist for maps."
+            await ctx.send(embed=embed)
+
+    @aliases.command(name="gamemodes")
+    async def gamemodes_aliases(self, ctx):
+        """`{prefix}aliases gamemodes` - *Lists all gamemode aliases*"""
+        embed = discord.Embed(title="Gamemode Aliases")
+        gamemodes = aliases.get_gamemodes()
+        paginator = Paginator(max_lines=20)
+        if gamemodes:
+            for alias, label in gamemodes.items():
+                paginator.add_line(f"{alias:<15} - {label}")
+            await paginator.create(ctx, embed=embed)
+        else:
+            embed.description = "No aliases exist for gamemodes."
             await ctx.send(embed=embed)
 
     @aliases.command(name="players")

--- a/bot/utils/aliases.py
+++ b/bot/utils/aliases.py
@@ -159,6 +159,9 @@ class Aliases:
     def get_maps(self):
         return self._aliases.get("maps", {})
 
+    def get_maps(self):
+        return self._aliases.get("gamemodes", {})
+
     def get_players(self):
         return self._aliases.get("players", {})
 

--- a/bot/utils/aliases.py
+++ b/bot/utils/aliases.py
@@ -159,7 +159,7 @@ class Aliases:
     def get_maps(self):
         return self._aliases.get("maps", {})
 
-    def get_maps(self):
+    def get_gamemodes(self):
         return self._aliases.get("gamemodes", {})
 
     def get_players(self):


### PR DESCRIPTION
Just a little helper to remind an on-again-off-again server owner and his various mods/captains what the game modes are for the switchmap command.

This code is currently running on our community server (Bowels).

Running `aliases` returns the normal list, including this:
![image](https://github.com/makupi/pavlov-bot/assets/70797475/a84ff2af-4b17-411a-b4a8-b89545efe4f0)

This block outputs as a result of ".aliases" or ".aliases gamemodes" by itself.

It shows up in the help section:

![image](https://github.com/makupi/pavlov-bot/assets/70797475/fd358101-28f8-4bd8-96c8-48b6d871c364)

The example file "aliases.json.example" now includes the full list.

There is merit for this to be added as either:

A) It's own json - `gamemodes.json.example`, for example which would be a little more work, but perhaps nicer - then `gamemodes` could be it's own command

B) Append the information to the `info` command, which is how I used to have it in my 2021 branch of the code; but this didn't display as nicely.

C) Append the information somewhere else, like the lists section, and have a separate command to invoke the prompt for gamemodes.

As a UX improvement, it would be good once this is implemented, to have detection on `switchmap/map` commands where the game_mode is malformed, it spits out the valid gamemodes to the user.

